### PR TITLE
Remove mowgli_init().

### DIFF
--- a/src/libguess/guess.c
+++ b/src/libguess/guess.c
@@ -22,8 +22,6 @@ guess_impl_register(const char *lang, guess_impl_f impl)
 static void
 guess_init(void)
 {
-    mowgli_init();
-
     /* check if already initialized */
     if (guess_impl_list != NULL)
         return;


### PR DESCRIPTION
The last commit changed the required libmowgli to >=2.0, so this isn't required anymore.
