### PR TITLE
Use AC_CONFIG_MACRO_DIR in configure.ac 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AC_PREREQ(2.59)
 AC_INIT([libguess], [1.1], [bugs+libguess@atheme.org])
 AC_CONFIG_SRCDIR([src/libguess/guess.c])
 AC_CONFIG_HEADER([src/libguess/autoconf.h])
+AC_CONFIG_MACRO_DIR([m4])
 
 AC_CANONICAL_HOST
 AC_CANONICAL_TARGET


### PR DESCRIPTION
Define m4 macro directory to make autoreconf work. Tested with Autoconf 2.69.
