### PR TITLE
Fix linking issues under OS X

### DIFF
--- a/buildsys.mk.in
+++ b/buildsys.mk.in
@@ -1,7 +1,8 @@
 #
-#  Copyright (c) 2007 - 2009, Jonathan Schleifer <js@webkeks.org>
+#  Copyright (c) 2007, 2008, 2009, 2010, 2011, 2012
+#  Jonathan Schleifer <js@webkeks.org>
 #
-#  https://webkeks.org/hg/buildsys/
+#  https://webkeks.org/git/?p=buildsys.git
 #
 #  Permission to use, copy, modify, and/or distribute this software for any
 #  purpose with or without fee is hereby granted, provided that the above
@@ -20,7 +21,8 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-PACKAGE = @PACKAGE@
+PACKAGE_NAME = @PACKAGE_NAME@
+PACKAGE_VERSION = @PACKAGE_VERSION@
 AS = @AS@
 CC = @CC@
 CXX = @CXX@
@@ -42,67 +44,85 @@ ERLCFLAGS = @ERLCFLAGS@
 OBJCFLAGS = @OBJCFLAGS@
 OBJCXXFLAGS = @OBJCXXFLAGS@
 LDFLAGS = @LDFLAGS@
+LDFLAGS_RPATH = @LDFLAGS_RPATH@
 LIBS = @LIBS@
 PYTHON_FLAGS = @PYTHON_FLAGS@
 PROG_IMPLIB_NEEDED = @PROG_IMPLIB_NEEDED@
 PROG_IMPLIB_LDFLAGS = @PROG_IMPLIB_LDFLAGS@
 PROG_SUFFIX = @EXEEXT@
-LIB_CPPFLAGS = @LIB_CPPFLAGS@
 LIB_CFLAGS = @LIB_CFLAGS@
 LIB_LDFLAGS = @LIB_LDFLAGS@
 LIB_PREFIX = @LIB_PREFIX@
 LIB_SUFFIX = @LIB_SUFFIX@
-PLUGIN_CPPFLAGS = @PLUGIN_CPPFLAGS@
 PLUGIN_CFLAGS = @PLUGIN_CFLAGS@
 PLUGIN_LDFLAGS = @PLUGIN_LDFLAGS@
 PLUGIN_SUFFIX = @PLUGIN_SUFFIX@
-RPATH_LDFLAGS = @RPATH_LDFLAGS@
 INSTALL_LIB = @INSTALL_LIB@
 UNINSTALL_LIB = @UNINSTALL_LIB@
 CLEAN_LIB = @CLEAN_LIB@
+AS_DEPENDS = @AS_DEPENDS@
+CC_DEPENDS = @CC_DEPENDS@
+CXX_DEPENDS = @CXX_DEPENDS@
+OBJC_DEPENDS = @OBJC_DEPENDS@
+OBJCXX_DEPENDS = @OBJCXX_DEPENDS@
 LN_S = @LN_S@
 MKDIR_P = mkdir -p
-INSTALL = @INSTALL@
+INSTALL = @INSTALL@ -p
 SHELL = @SHELL@
 MSGFMT = @MSGFMT@
+JAVAC = @JAVAC@
+JAVACFLAGS = @JAVACFLAGS@
+JAR = @JAR@
+WINDRES = @WINDRES@
 prefix = @prefix@
 exec_prefix = @exec_prefix@
 bindir = @bindir@
 libdir = @libdir@
-plugindir ?= ${libdir}/${PACKAGE}
+pkgconfigdir = @pkgconfigdir@
+plugindir ?= ${libdir}/${PACKAGE_NAME}
 datarootdir = @datarootdir@
 datadir = @datadir@
 includedir = @includedir@
-includesubdir ?= ${PACKAGE}
+includesubdir ?= ${PACKAGE_NAME}
+localedir = @localedir@
+localename ?= ${PACKAGE_NAME}
 mandir = @mandir@
 mansubdir ?= man1
 
-OBJS1  = ${SRCS:.c=.o}
-OBJS2  = ${OBJS1:.cc=.o}
-OBJS3  = ${OBJS2:.cxx=.o}
-OBJS4  = ${OBJS3:.d=.o}
-OBJS5  = ${OBJS4:.erl=.beam}
-OBJS6  = ${OBJS5:.m=.o}
-OBJS7  = ${OBJS6:.mm=.o}
-OBJS8  = ${OBJS7:.py=.pyc}
-OBJS9  = ${OBJS8:.xpm=.o}
-OBJS10 = ${OBJS9:.S=.o}
-OBJS  += ${OBJS10:.po=.gmo}
+OBJS1 = ${SRCS:.c=.o}
+OBJS2 = ${OBJS1:.cc=.o}
+OBJS3 = ${OBJS2:.cxx=.o}
+OBJS4 = ${OBJS3:.d=.o}
+OBJS5 = ${OBJS4:.erl=.beam}
+OBJS6 = ${OBJS5:.java=.class}
+OBJS7 = ${OBJS6:.m=.o}
+OBJS8 = ${OBJS7:.mm=.o}
+OBJS9 = ${OBJS8:.py=.pyc}
+OBJS10 = ${OBJS9:.rc=.o}
+OBJS11 = ${OBJS10:.S=.o}
+OBJS += ${OBJS11:.xpm=.o}
+
+LIB_OBJS = ${OBJS:.o=.lib.o}
+PLUGIN_OBJS = ${OBJS:.o=.plugin.o}
+
+MO_FILES = ${LOCALES:.po=.mo}
 
 .SILENT:
 .SUFFIXES:
-.SUFFIXES: .beam .c .cc .cxx .d .dep .erl .gmo .m .mm .o .po .py .pyc .xpm .S
-.PHONY: all subdirs pre-depend depend install install-extra uninstall uninstall-extra clean distclean
+.SUFFIXES: .beam .c .c.dep .cc .cc.dep .class .cxx .cxx.dep .d .erl .lib.o .java .mo .m .m.dep .mm .mm.dep .o .plugin.o .po .py .pyc .rc .S .S.dep .xpm
+.PHONY: all subdirs pre-depend depend install install-extra uninstall uninstall-extra clean distclean locales ${SUBDIRS}
 
 all:
-	for i in subdirs depend ${STATIC_LIB} ${STATIC_LIB_NOINST} ${LIB} ${LIB_NOINST} ${PLUGIN} ${PLUGIN_NOINST} ${PROG} ${PROG_NOINST}; do \
-		${MAKE} ${MFLAGS} $$i || exit 1; \
-	done
+	${MAKE} ${MFLAGS} subdirs
+	${MAKE} ${MFLAGS} depend
+	${MAKE} ${STATIC_LIB} ${STATIC_LIB_NOINST} ${STATIC_PIC_LIB} ${STATIC_PIC_LIB_NOINST} ${SHARED_LIB} ${SHARED_LIB_NOINST} ${PLUGIN} ${PLUGIN_NOINST} ${PROG} ${PROG_NOINST} ${JARFILE} locales
 
-subdirs:
-	for i in ${SUBDIRS}; do \
+subdirs: ${SUBDIRS}
+
+${SUBDIRS}:
+	for i in $@; do \
 		${DIR_ENTER}; \
-		${MAKE} ${MFLAGS} || exit 1; \
+		${MAKE} ${MFLAGS} || exit $$?; \
 		${DIR_LEAVE}; \
 	done
 
@@ -113,32 +133,38 @@ depend: pre-depend ${SRCS}
 	for i in ${SRCS}; do \
 		case $$i in \
 			*.c) \
-				test $$i -nt .deps && regen=1; \
-				deps="$$deps $${i%.c}.dep"; \
+				if test x"${CC_DEPENDS}" = x"yes"; then \
+					test $$i -nt .deps && regen=1; \
+					deps="$$deps $$i.dep"; \
+				fi; \
 				;; \
-			*.cc) \
-				test $$i -nt .deps && regen=1; \
-				deps="$$deps $${i%.cc}.dep"; \
-				;; \
-			*.cxx) \
-				test $$i -nt .deps && regen=1; \
-				deps="$$deps $${i%.cxx}.dep"; \
+			*.cc | *.cxx) \
+				if test x"${CXX_DEPENDS}" = x"yes"; then \
+					test $$i -nt .deps && regen=1; \
+					deps="$$deps $$i.dep"; \
+				fi; \
 				;; \
 			*.m) \
-				test $$i -nt .deps && regen=1; \
-				deps="$$deps $${i%.m}.dep"; \
+				if test x"${OBJC_DEPENDS}" = x"yes"; then \
+					test $$i -nt .deps && regen=1; \
+					deps="$$deps $$i.dep"; \
+				fi; \
 				;; \
 			*.mm) \
-				test $$i -nt .deps && regen=1; \
-				deps="$$deps $${i%.mm}.dep"; \
+				if test x"${OBJCXX_DEPENDS}" = x"yes"; then \
+					test $$i -nt .deps && regen=1; \
+					deps="$$deps $$i.dep"; \
+				fi; \
 				;; \
 			*.S) \
-				test $$i -nt .deps && regen=1; \
-				deps="$$deps $${i%.S}.dep"; \
+				if test x"${AS_DEPENDS}" = x"yes"; then \
+					test $$i -nt .deps && regen=1; \
+					deps="$$deps $$i.dep"; \
+				fi; \
 				;; \
 		esac; \
 	done; \
-	if test x"$$regen" = x"1" -a x"$$deps" != "x"; then \
+	if test x"$$regen" = x"1" -a x"$$deps" != x""; then \
 		${DEPEND_STATUS}; \
 		if ${MAKE} ${MFLAGS} $$deps && cat $$deps >.deps; then \
 			rm -f $$deps; \
@@ -150,53 +176,202 @@ depend: pre-depend ${SRCS}
 		fi; \
 	fi
 
-.c.dep .cc.dep .cxx.dep .m.dep .mm.dep .S.dep:
-	${CPP} ${CPPFLAGS} -M $< >$@ || (rm -f $@; exit 1)
+.c.c.dep:
+	${CPP} ${CPPFLAGS} ${CFLAGS} -M $< | \
+	sed 's/^\([^\.]*\)\.o:/\1.o \1.lib.o \1.plugin.o:/' >$@ || \
+	{ rm -f $@; false; }
 
-.d.dep:
-.xpm.dep:
+.cc.cc.dep .cxx.cxx.dep:
+	${CPP} ${CPPFLAGS} ${CXXFLAGS} -M $< | \
+	sed 's/^\([^\.]*\)\.o:/\1.o \1.lib.o \1.plugin.o:/' >$@ || \
+	{ rm -f $@; false; }
+
+.m.m.dep:
+	${CPP} ${CPPFLAGS} ${OBJCFLAGS} -M $< | \
+	sed 's/^\([^\.]*\)\.o:/\1.o \1.lib.o \1.plugin.o:/' >$@ || \
+	{ rm -f $@; false; }
+
+.mm.mm.dep:
+	${CPP} ${CPPFLAGS} ${OBJCPPFLAGS} -M $< | \
+	sed 's/^\([^\.]*\)\.o:/\1.o \1.lib.o \1.plugin.o:/' >$@ || \
+	{ rm -f $@; false; }
+
+.S.S.dep:
+	${CPP} ${CPPFLAGS} ${ASFLAGS} -M $< | \
+	sed 's/^\([^\.]*\)\.o:/\1.o \1.lib.o \1.plugin.o:/' >$@ || \
+	{ rm -f $@; false; }
 
 pre-depend:
 
-${PROG} ${PROG_NOINST}: ${EXT_DEPS} ${OBJS}
+${PROG} ${PROG_NOINST}: ${EXT_DEPS} ${OBJS} ${OBJS_EXTRA}
 	${LINK_STATUS}
-	if ${LD} -o $@ ${OBJS} ${LDFLAGS} ${LIBS}; then \
+	if ${LD} -o $@ ${OBJS} ${OBJS_EXTRA} ${LDFLAGS} ${LIBS}; then \
 		${LINK_OK}; \
 	else \
 		${LINK_FAILED}; \
 	fi
 
-${LIB} ${LIB_NOINST}: ${EXT_DEPS} ${OBJS}
-	case $@ in \
-		*.a) \
-			${MAKE} ${MFLAGS} STATIC_LIB=${LIB} LIB= $@ || exit 1 \
-			;; \
-		*) \
-			${LINK_STATUS}; \
-			if ${LD} -o $@ ${OBJS} ${LIB_LDFLAGS} ${LDFLAGS} ${LIBS}; then \
-				${LINK_OK}; \
-			else \
-				${LINK_FAILED}; \
-			fi \
-			;; \
-	esac
-
-${PLUGIN} ${PLUGIN_NOINST}: ${EXT_DEPS} ${OBJS}
+${JARFILE}: ${EXT_DEPS} ${JAR_MANIFEST} ${OBJS} ${OBJS_EXTRA}
 	${LINK_STATUS}
-	if ${LD} -o $@ ${OBJS} ${PLUGIN_LDFLAGS} ${LDFLAGS} ${LIBS}; then \
+	if test x"${JAR_MANIFEST}" != x""; then \
+		if ${JAR} cfm ${JARFILE} ${JAR_MANIFEST} ${OBJS} ${OBJS_EXTRA}; then \
+			${LINK_OK}; \
+		else \
+			${LINK_FAILED}; \
+		fi \
+	else \
+		if ${JAR} cf ${JARFILE} ${OBJS} ${OBJS_EXTRA}; then \
+			${LINK_OK}; \
+		else \
+			${LINK_FAILED}; \
+		fi \
+	fi
+
+${SHARED_LIB} ${SHARED_LIB_NOINST}: ${EXT_DEPS} ${LIB_OBJS} ${LIB_OBJS_EXTRA}
+	${LINK_STATUS}; \
+	objs=""; \
+	ars=""; \
+	for i in ${LIB_OBJS} ${LIB_OBJS_EXTRA}; do \
+		case $$i in \
+			*.a) \
+				ars="$$ars $$i" \
+				;; \
+			*.o) \
+				objs="$$objs $$i" \
+				;; \
+		esac \
+	done; \
+	for i in $$ars; do \
+		dir=".$$(echo $$i | sed 's/\//_/g').objs"; \
+		rm -fr $$dir; \
+		mkdir -p $$dir; \
+		cd $$dir; \
+		${AR} x ../$$i; \
+		for j in *.o; do \
+			objs="$$objs $$dir/$$j"; \
+		done; \
+		cd ..; \
+	done; \
+	if ${LD} -o $@ $$objs ${LIB_LDFLAGS} ${LDFLAGS} ${LIBS}; then \
 		${LINK_OK}; \
 	else \
 		${LINK_FAILED}; \
-	fi
+	fi; \
+	for i in $$ars; do \
+		dir=".$$(echo $$i | sed 's/\//_/g').objs"; \
+		rm -fr $$dir; \
+	done
 
-${STATIC_LIB} ${STATIC_LIB_NOINST}: ${EXT_DEPS} ${OBJS}
+${PLUGIN} ${PLUGIN_NOINST}: ${EXT_DEPS} ${PLUGIN_OBJS}
 	${LINK_STATUS}
-	if ${AR} cr $@ ${OBJS} && ${RANLIB} $@; then \
+	objs=""; \
+	ars=""; \
+	for i in ${PLUGIN_OBJS}; do \
+		case $$i in \
+			*.a) \
+				ars="$$ars $$i" \
+				;; \
+			*.o) \
+				objs="$$objs $$i" \
+				;; \
+		esac \
+	done; \
+	for i in $$ars; do \
+		dir=".$$(echo $$i | sed 's/\//_/g').objs"; \
+		rm -fr $$dir; \
+		mkdir -p $$dir; \
+		cd $$dir; \
+		${AR} x ../$$i; \
+		for j in *.o; do \
+			objs="$$objs $$dir/$$j"; \
+		done; \
+		cd ..; \
+	done; \
+	if ${LD} -o $@ $$objs ${PLUGIN_LDFLAGS} ${LDFLAGS} ${LIBS}; then \
+		${LINK_OK}; \
+	else \
+		${LINK_FAILED}; \
+	fi; \
+	for i in $$ars; do \
+		dir=".$$(echo $$i | sed 's/\//_/g').objs"; \
+		rm -fr $$dir; \
+	done
+
+${STATIC_LIB} ${STATIC_LIB_NOINST}: ${EXT_DEPS} ${OBJS} ${OBJS_EXTRA}
+	${LINK_STATUS}
+	rm -f $@
+	objs=""; \
+	ars=""; \
+	for i in ${OBJS} ${OBJS_EXTRA}; do \
+		case $$i in \
+			*.a) \
+				ars="$$ars $$i" \
+				;; \
+			*.o) \
+				objs="$$objs $$i" \
+				;; \
+		esac \
+	done; \
+	for i in $$ars; do \
+		dir=".$$(echo $$i | sed 's/\//_/g').objs"; \
+		rm -fr $$dir; \
+		mkdir -p $$dir; \
+		cd $$dir; \
+		${AR} x ../$$i; \
+		for j in *.o; do \
+			objs="$$objs $$dir/$$j"; \
+		done; \
+		cd ..; \
+	done; \
+	if ${AR} cr $@ $$objs && ${RANLIB} $@; then \
 		${LINK_OK}; \
 	else \
 		${LINK_FAILED}; \
 		rm -f $@; \
-	fi
+	fi; \
+	for i in $$ars; do \
+		dir=".$$(echo $$i | sed 's/\//_/g').objs"; \
+		rm -fr $$dir; \
+	done
+
+${STATIC_PIC_LIB} ${STATIC_PIC_LIB_NOINST}: ${EXT_DEPS} ${LIB_OBJS} ${LIB_OBJS_EXTRA}
+	${LINK_STATUS}
+	rm -f $@
+	objs=""; \
+	ars=""; \
+	for i in ${LIB_OBJS} ${LIB_OBJS_EXTRA}; do \
+		case $$i in \
+			*.a) \
+				ars="$$ars $$i" \
+				;; \
+			*.o) \
+				objs="$$objs $$i" \
+				;; \
+		esac \
+	done; \
+	for i in $$ars; do \
+		dir=".$$(echo $$i | sed 's/\//_/g').objs"; \
+		rm -fr $$dir; \
+		mkdir -p $$dir; \
+		cd $$dir; \
+		${AR} x ../$$i; \
+		for j in *.o; do \
+			objs="$$objs $$dir/$$j"; \
+		done; \
+		cd ..; \
+	done; \
+	if ${AR} cr $@ $$objs && ${RANLIB} $@; then \
+		${LINK_OK}; \
+	else \
+		${LINK_FAILED}; \
+		rm -f $@; \
+	fi; \
+	for i in $$ars; do \
+		dir=".$$(echo $$i | sed 's/\//_/g').objs"; \
+		rm -fr $$dir; \
+	done
+
+locales: ${MO_FILES}
 
 .c.o:
 	${COMPILE_STATUS}
@@ -205,6 +380,20 @@ ${STATIC_LIB} ${STATIC_LIB_NOINST}: ${EXT_DEPS} ${OBJS}
 	else \
 		${COMPILE_FAILED}; \
 	fi
+.c.lib.o:
+	${COMPILE_LIB_STATUS}
+	if ${CC} ${LIB_CFLAGS} ${CFLAGS} ${CPPFLAGS} -c -o $@ $<; then \
+		${COMPILE_LIB_OK}; \
+	else \
+		${COMPILE_LIB_FAILED}; \
+	fi
+.c.plugin.o:
+	${COMPILE_PLUGIN_STATUS}
+	if ${CC} ${PLUGIN_CFLAGS} ${CFLAGS} ${CPPFLAGS} -c -o $@ $<; then \
+		${COMPILE_PLUGIN_OK}; \
+	else \
+		${COMPILE_PLUGIN_FAILED}; \
+	fi
 
 .cc.o .cxx.o:
 	${COMPILE_STATUS}
@@ -212,6 +401,20 @@ ${STATIC_LIB} ${STATIC_LIB_NOINST}: ${EXT_DEPS} ${OBJS}
 		${COMPILE_OK}; \
 	else \
 		${COMPILE_FAILED}; \
+	fi
+.cc.lib.o .cxx.lib.o:
+	${COMPILE_LIB_STATUS}
+	if ${CXX} ${LIB_CFLAGS} ${CXXFLAGS} ${CPPFLAGS} -c -o $@ $<; then \
+		${COMPILE_LIB_OK}; \
+	else \
+		${COMPILE_LIB_FAILED}; \
+	fi
+.cc.plugin.o .cxx.plugin.o:
+	${COMPILE_PLUGIN_STATUS}
+	if ${CXX} ${PLUGIN_CFLAGS} ${CXXFLAGS} ${CPPFLAGS} -c -o $@ $<; then \
+		${COMPILE_PLUGIN_OK}; \
+	else \
+		${COMPILE_PLUGIN_FAILED}; \
 	fi
 
 .d.o:
@@ -238,12 +441,34 @@ ${STATIC_LIB} ${STATIC_LIB_NOINST}: ${EXT_DEPS} ${OBJS}
 		${COMPILE_FAILED}; \
 	fi
 
+.java.class:
+	${COMPILE_STATUS}
+	if ${JAVAC} ${JAVACFLAGS} $<; then \
+		${COMPILE_OK}; \
+	else \
+		${COMPILE_FAILED}; \
+	fi
+
 .m.o:
 	${COMPILE_STATUS}
 	if ${OBJC} ${OBJCFLAGS} ${CPPFLAGS} -c -o $@ $<; then \
 		${COMPILE_OK}; \
 	else \
 		${COMPILE_FAILED}; \
+	fi
+.m.lib.o:
+	${COMPILE_LIB_STATUS}
+	if ${OBJC} ${LIB_CFLAGS} ${OBJCFLAGS} ${CPPFLAGS} -c -o $@ $<; then \
+		${COMPILE_LIB_OK}; \
+	else \
+		${COMPILE_LIB_FAILED}; \
+	fi
+.m.plugin.o:
+	${COMPILE_PLUGIN_STATUS}
+	if ${OBJC} ${PLUGIN_CFLAGS} ${OBJCFLAGS} ${CPPFLAGS} -c -o $@ $<; then \
+		${COMPILE_PLUGIN_OK}; \
+	else \
+		${COMPILE_PLUGIN_FAILED}; \
 	fi
 
 .mm.o:
@@ -253,8 +478,22 @@ ${STATIC_LIB} ${STATIC_LIB_NOINST}: ${EXT_DEPS} ${OBJS}
 	else \
 		${COMPILE_FAILED}; \
 	fi
+.mm.lib.o:
+	${COMPILE_LIB_STATUS}
+	if ${OBJCXX} ${LIB_CFLAGS} ${OBJCXXFLAGS} ${OBJCFLAGS} ${CXXFLAGS} ${CPPFLAGS} -c -o $@ $<; then \
+		${COMPILE_LIB_OK}; \
+	else \
+		${COMPILE_LIB_FAILED}; \
+	fi
+.mm.plugin.o:
+	${COMPILE_PLUGIN_STATUS}
+	if ${OBJCXX} ${PLUGIN_CFLAGS} ${OBJCXXFLAGS} ${OBJCFLAGS} ${CXXFLAGS} ${CPPFLAGS} -c -o $@ $<; then \
+		${COMPILE_PLUGIN_OK}; \
+	else \
+		${COMPILE_PLUGIN_FAILED}; \
+	fi
 
-.po.gmo:
+.po.mo:
 	${COMPILE_STATUS}
 	if ${MSGFMT} -c -o $@ $<; then \
 		${COMPILE_OK}; \
@@ -270,9 +509,9 @@ ${STATIC_LIB} ${STATIC_LIB_NOINST}: ${EXT_DEPS} ${OBJS}
 		${COMPILE_FAILED}; \
 	fi
 
-.xpm.o:
+.rc.o .rc.lib.o .rc.plugin.o:
 	${COMPILE_STATUS}
-	if ${CC} ${CFLAGS} ${CPPFLAGS} -x c -c -o $@ $<; then \
+	if ${WINDRES} -J rc -O coff -o $@ $<; then \
 		${COMPILE_OK}; \
 	else \
 		${COMPILE_FAILED}; \
@@ -285,24 +524,60 @@ ${STATIC_LIB} ${STATIC_LIB_NOINST}: ${EXT_DEPS} ${OBJS}
 	else \
 		${COMPILE_FAILED}; \
 	fi
+.S.lib.o:
+	${COMPILE_LIB_STATUS}
+	if ${AS} ${LIB_CFLAGS} ${ASFLAGS} ${CPPFLAGS} -c -o $@ $<; then \
+		${COMPILE_LIB_OK}; \
+	else \
+		${COMPILE_LIB_FAILED}; \
+	fi
+.S.plugin.o:
+	${COMPILE_PLUGIN_STATUS}
+	if ${AS} ${PLUGIN_CFLAGS} ${ASFLAGS} ${CPPFLAGS} -c -o $@ $<; then \
+		${COMPILE_PLUGIN_OK}; \
+	else \
+		${COMPILE_PLUGIN_FAILED}; \
+	fi
 
-install: ${LIB} ${STATIC_LIB} ${PLUGIN} ${PROG} install-extra
+.xpm.o:
+	${COMPILE_STATUS}
+	if ${CC} ${CFLAGS} ${CPPFLAGS} -x c -c -o $@ $<; then \
+		${COMPILE_OK}; \
+	else \
+		${COMPILE_FAILED}; \
+	fi
+.xpm.lib.o:
+	${COMPILE_LIB_STATUS}
+	if ${CC} ${LIB_CFLAGS} ${CFLAGS} ${CPPFLAGS} -x c -c -o $@ $<; then \
+		${COMPILE_LIB_OK}; \
+	else \
+		${COMPILE_LIB_FAILED}; \
+	fi
+.xpm.plugin.o:
+	${COMPILE_PLUGIN_STATUS}
+	if ${CC} ${PLUGIN_CFLAGS} ${CFLAGS} ${CPPFLAGS} -x c -c -o $@ $<; then \
+		${COMPILE_PLUGIN_OK}; \
+	else \
+		${COMPILE_PLUGIN_FAILED}; \
+	fi
+
+install: install-extra
 	for i in ${SUBDIRS}; do \
 		${DIR_ENTER}; \
-		${MAKE} ${MFLAGS} install || exit 1; \
+		${MAKE} ${MFLAGS} install || exit $$?; \
 		${DIR_LEAVE}; \
 	done
 
-	for i in ${LIB}; do \
+	for i in ${SHARED_LIB}; do \
 		${INSTALL_STATUS}; \
-		if ${MKDIR_P} ${DESTDIR}${libdir} && ${INSTALL_LIB}; then \
+		if ${MKDIR_P} ${DESTDIR}${libdir} ${INSTALL_LIB}; then \
 			${INSTALL_OK}; \
 		else \
 			${INSTALL_FAILED}; \
 		fi \
 	done
 
-	for i in ${STATIC_LIB}; do \
+	for i in ${STATIC_LIB} ${STATIC_PIC_LIB}; do \
 		${INSTALL_STATUS}; \
 		if ${MKDIR_P} ${DESTDIR}${libdir} && ${INSTALL} -m 644 $$i ${DESTDIR}${libdir}/$$i; then \
 			${INSTALL_OK}; \
@@ -322,7 +597,7 @@ install: ${LIB} ${STATIC_LIB} ${PLUGIN} ${PROG} install-extra
 
 	for i in ${DATA}; do \
 		${INSTALL_STATUS}; \
-		if ${MKDIR_P} $$(dirname ${DESTDIR}${datadir}/${PACKAGE}/$$i) && ${INSTALL} -m 644 $$i ${DESTDIR}${datadir}/${PACKAGE}/$$i; then \
+		if ${MKDIR_P} $$(dirname ${DESTDIR}${datadir}/${PACKAGE_NAME}/$$i) && ${INSTALL} -m 644 $$i ${DESTDIR}${datadir}/${PACKAGE_NAME}/$$i; then \
 			${INSTALL_OK}; \
 		else \
 			${INSTALL_FAILED}; \
@@ -347,6 +622,15 @@ install: ${LIB} ${STATIC_LIB} ${PLUGIN} ${PROG} install-extra
 		fi \
 	done
 
+	for i in ${MO_FILES}; do \
+		${INSTALL_STATUS}; \
+		if ${MKDIR_P} ${DESTDIR}${localedir}/$${i%.mo}/LC_MESSAGES && ${INSTALL} -m 644 $$i ${DESTDIR}${localedir}/$${i%.mo}/LC_MESSAGES/${localename}.mo; then \
+			${INSTALL_OK}; \
+		else \
+			${INSTALL_FAILED}; \
+		fi \
+	done
+
 	for i in ${MAN}; do \
 		${INSTALL_STATUS}; \
 		if ${MKDIR_P} ${DESTDIR}${mandir}/${mansubdir} && ${INSTALL} -m 644 $$i ${DESTDIR}${mandir}/${mansubdir}/$$i; then \
@@ -361,13 +645,13 @@ install-extra:
 uninstall: uninstall-extra
 	for i in ${SUBDIRS}; do \
 		${DIR_ENTER}; \
-		${MAKE} ${MFLAGS} uninstall || exit 1; \
+		${MAKE} ${MFLAGS} uninstall || exit $$?; \
 		${DIR_LEAVE}; \
 	done
 
-	for i in ${LIB}; do \
+	for i in ${SHARED_LIB}; do \
 		if test -f ${DESTDIR}${libdir}/$$i; then \
-			if ${UNINSTALL_LIB}; then \
+			if : ${UNINSTALL_LIB}; then \
 				${DELETE_OK}; \
 			else \
 				${DELETE_FAILED}; \
@@ -375,7 +659,7 @@ uninstall: uninstall-extra
 		fi; \
 	done
 
-	for i in ${STATIC_LIB}; do \
+	for i in ${STATIC_LIB} ${STATIC_PIC_LIB}; do \
 		if test -f ${DESTDIR}${libdir}/$$i; then \
 			if rm -f ${DESTDIR}${libdir}/$$i; then \
 				${DELETE_OK}; \
@@ -397,14 +681,16 @@ uninstall: uninstall-extra
 	-rmdir ${DESTDIR}${plugindir} >/dev/null 2>&1
 
 	for i in ${DATA}; do \
-		if test -f ${DESTDIR}${datadir}/${PACKAGE}/$$i; then \
-			if rm -f ${DESTDIR}${datadir}/${PACKAGE}/$$i; then \
+		if test -f ${DESTDIR}${datadir}/${PACKAGE_NAME}/$$i; then \
+			if rm -f ${DESTDIR}${datadir}/${PACKAGE_NAME}/$$i; then \
 				${DELETE_OK}; \
 			else \
 				${DELETE_FAILED}; \
 			fi \
-		fi \
+		fi; \
+		rmdir "$$(dirname ${DESTDIR}${datadir}/${PACKAGE_NAME}/$$i)" >/dev/null 2>&1 || true; \
 	done
+	-rmdir ${DESTDIR}${datadir}/${PACKAGE_NAME} >/dev/null 2>&1
 
 	for i in ${PROG}; do \
 		if test -f ${DESTDIR}${bindir}/$$i; then \
@@ -427,6 +713,16 @@ uninstall: uninstall-extra
 	done
 	-rmdir ${DESTDIR}${includedir}/${includesubdir} >/dev/null 2>&1
 
+	for i in ${MO_FILES}; do \
+		if test -f ${DESTDIR}${localedir}/$${i%.mo}/LC_MESSAGES/${localename}.mo; then \
+			if rm -f ${DESTDIR}${localedir}/$${i%.mo}/LC_MESSAGES/${localename}.mo; then \
+				${DELETE_OK}; \
+			else \
+				${DELETE_FAILED}; \
+			fi \
+		fi \
+	done
+
 	for i in ${MAN}; do \
 		if test -f ${DESTDIR}${mandir}/${mansubdir}/$$i; then \
 			if rm -f ${DESTDIR}${mandir}/${mansubdir}/$$i; then \
@@ -442,11 +738,11 @@ uninstall-extra:
 clean:
 	for i in ${SUBDIRS}; do \
 		${DIR_ENTER}; \
-		${MAKE} ${MFLAGS} clean || exit 1; \
+		${MAKE} ${MFLAGS} clean || exit $$?; \
 		${DIR_LEAVE}; \
 	done
 
-	for i in ${DEPS} ${OBJS} ${PROG} ${PROG_NOINST} ${LIB} ${LIB_NOINST} ${STATIC_LIB} ${STATIC_LIB_NOINST} ${PLUGIN} ${PLUGIN_NOINST} ${CLEAN} ${CLEAN_LIB}; do \
+	for i in ${DEPS} ${OBJS} ${OBJS_EXTRA} ${LIB_OBJS} ${LIB_OBJS_EXTRA} ${PLUGIN_OBJS} ${PROG} ${PROG_NOINST} ${SHARED_LIB} ${SHARED_LIB_NOINST} ${STATIC_LIB} ${STATIC_LIB_NOINST} ${STATIC_PIC_LIB} ${STATIC_PIC_LIB_NOINST} ${PLUGIN} ${PLUGIN_NOINST} ${CLEAN_LIB} ${MO_FILES} ${CLEAN}; do \
 		if test -f $$i -o -d $$i; then \
 			if rm -fr $$i; then \
 				${DELETE_OK}; \
@@ -459,7 +755,7 @@ clean:
 distclean: clean
 	for i in ${SUBDIRS}; do \
 		${DIR_ENTER}; \
-		${MAKE} ${MFLAGS} distclean || exit 1; \
+		${MAKE} ${MFLAGS} distclean || exit $$?; \
 		${DIR_LEAVE}; \
 	done
 
@@ -473,21 +769,27 @@ distclean: clean
 		fi \
 	done
 
-DIR_ENTER = printf "\033[K\033[0;36mEntering directory \033[1;36m$$i\033[0;36m.\033[0m\n"; cd $$i || exit 1
-DIR_LEAVE = printf "\033[K\033[0;36mLeaving directory \033[1;36m$$i\033[0;36m.\033[0m\n"; cd .. || exit 1
-DEPEND_STATUS = printf "\033[K\033[0;33mGenerating dependencies...\033[0m\r"
-DEPEND_OK = printf "\033[K\033[0;32mSuccessfully generated dependencies.\033[0m\n"
-DEPEND_FAILED = printf "\033[K\033[0;31mFailed to generate dependencies!\033[0m\n"; exit 1
-COMPILE_STATUS = printf "\033[K\033[0;33mCompiling \033[1;33m$<\033[0;33m...\033[0m\r"
-COMPILE_OK = printf "\033[K\033[0;32mSuccessfully compiled \033[1;32m$<\033[0;32m.\033[0m\n"
-COMPILE_FAILED = printf "\033[K\033[0;31mFailed to compile \033[1;31m$<\033[0;31m!\033[0m\n"; exit 1
-LINK_STATUS = printf "\033[K\033[0;33mLinking \033[1;33m$@\033[0;33m...\033[0m\r"
-LINK_OK = printf "\033[K\033[0;32mSuccessfully linked \033[1;32m$@\033[0;32m.\033[0m\n"
-LINK_FAILED = printf "\033[K\033[0;31mFailed to link \033[1;31m$@\033[0;31m!\033[0m\n"; exit 1
-INSTALL_STATUS = printf "\033[K\033[0;33mInstalling \033[1;33m$$i\033[0;33m...\033[0m\r"
-INSTALL_OK = printf "\033[K\033[0;32mSuccessfully installed \033[1;32m$$i\033[0;32m.\033[0m\n"
-INSTALL_FAILED = printf "\033[K\033[0;31mFailed to install \033[1;31m$$i\033[0;31m!\033[0m\n"; exit 1
-DELETE_OK = printf "\033[K\033[0;34mDeleted \033[1;34m$$i\033[0;34m.\033[0m\n"
-DELETE_FAILED = printf "\033[K\033[0;31mFailed to delete \033[1;31m$$i\033[0;31m!\033[0m\n"; exit 1
+DIR_ENTER = printf "@TERM_EL@@TERM_SETAF6@Entering directory @TERM_BOLD@$$i@TERM_SGR0@@TERM_SETAF6@.@TERM_SGR0@\n"; cd $$i || exit $$?
+DIR_LEAVE = printf "@TERM_EL@@TERM_SETAF6@Leaving directory @TERM_BOLD@$$i@TERM_SGR0@@TERM_SETAF6@.@TERM_SGR0@\n"; cd .. || exit $$?
+DEPEND_STATUS = printf "@TERM_EL@@TERM_SETAF3@Generating dependencies...@TERM_SGR0@\r"
+DEPEND_OK = printf "@TERM_EL@@TERM_SETAF2@Successfully generated dependencies.@TERM_SGR0@\n"
+DEPEND_FAILED = err=$$?; printf "@TERM_EL@@TERM_SETAF1@Failed to generate dependencies!@TERM_SGR0@\n"; exit $$err
+COMPILE_STATUS = printf "@TERM_EL@@TERM_SETAF3@Compiling @TERM_BOLD@$<@TERM_SGR0@@TERM_SETAF3@...@TERM_SGR0@\r"
+COMPILE_OK = printf "@TERM_EL@@TERM_SETAF2@Successfully compiled @TERM_BOLD@$<@TERM_SGR0@@TERM_SETAF2@.@TERM_SGR0@\n"
+COMPILE_FAILED = err=$$?; printf "@TERM_EL@@TERM_SETAF1@Failed to compile @TERM_BOLD@$<@TERM_SGR0@@TERM_SETAF1@!@TERM_SGR0@\n"; exit $$err
+COMPILE_LIB_STATUS = printf "@TERM_EL@@TERM_SETAF3@Compiling @TERM_BOLD@$<@TERM_SGR0@@TERM_SETAF3@ (lib)...@TERM_SGR0@\r"
+COMPILE_LIB_OK = printf "@TERM_EL@@TERM_SETAF2@Successfully compiled @TERM_BOLD@$<@TERM_SGR0@@TERM_SETAF2@ (lib).@TERM_SGR0@\n"
+COMPILE_LIB_FAILED = err=$$?; printf "@TERM_EL@@TERM_SETAF1@Failed to compile @TERM_BOLD@$<@TERM_SGR0@@TERM_SETAF1@ (lib)!@TERM_SGR0@\n"; exit $$err
+COMPILE_PLUGIN_STATUS = printf "@TERM_EL@@TERM_SETAF3@Compiling @TERM_BOLD@$<@TERM_SGR0@@TERM_SETAF3@ (plugin)...@TERM_SGR0@\r"
+COMPILE_PLUGIN_OK = printf "@TERM_EL@@TERM_SETAF2@Successfully compiled @TERM_BOLD@$<@TERM_SGR0@@TERM_SETAF2@ (plugin).@TERM_SGR0@\n"
+COMPILE_PLUGIN_FAILED = err=$$?; printf "@TERM_EL@@TERM_SETAF1@Failed to compile @TERM_BOLD@$<@TERM_SGR0@@TERM_SETAF1@ (plugin)!@TERM_SGR0@\n"; exit $$err
+LINK_STATUS = printf "@TERM_EL@@TERM_SETAF3@Linking @TERM_BOLD@$@@TERM_SGR0@@TERM_SETAF3@...@TERM_SGR0@\r"
+LINK_OK = printf "@TERM_EL@@TERM_SETAF2@Successfully linked @TERM_BOLD@$@@TERM_SGR0@@TERM_SETAF2@.@TERM_SGR0@\n"
+LINK_FAILED = err=$$?; printf "@TERM_EL@@TERM_SETAF1@Failed to link @TERM_BOLD@$@@TERM_SGR0@@TERM_SETAF1@!@TERM_SGR0@\n"; exit $$err
+INSTALL_STATUS = printf "@TERM_EL@@TERM_SETAF3@Installing @TERM_BOLD@$$i@TERM_SGR0@@TERM_SETAF3@...@TERM_SGR0@\r"
+INSTALL_OK = printf "@TERM_EL@@TERM_SETAF2@Successfully installed @TERM_BOLD@$$i@TERM_SGR0@@TERM_SETAF2@.@TERM_SGR0@\n"
+INSTALL_FAILED = err=$$?; printf "@TERM_EL@@TERM_SETAF1@Failed to install @TERM_BOLD@$$i@TERM_SGR0@@TERM_SETAF1@!@TERM_SGR0@\n"; exit $$err
+DELETE_OK = printf "@TERM_EL@@TERM_SETAF4@Deleted @TERM_BOLD@$$i@TERM_SGR0@@TERM_SETAF4@.@TERM_SGR0@\n"
+DELETE_FAILED = err=$$?; printf "@TERM_EL@@TERM_SETAF1@Failed to delete @TERM_BOLD@$$i@TERM_SGR0@@TERM_SETAF1@!@TERM_SGR0@\n"; exit $$err
 
 include .deps

--- a/configure.ac
+++ b/configure.ac
@@ -55,8 +55,6 @@ fi
 
 AC_SUBST(EXAMPLES_BUILD)
 
-BUILDSYS_TOUCH_DEPS
-
 AC_CONFIG_FILES([buildsys.mk extra.mk libguess.pc])
 AC_OUTPUT
 

--- a/extra.mk.in
+++ b/extra.mk.in
@@ -73,7 +73,6 @@ INSTALL_PROGRAM ?= @INSTALL_PROGRAM@
 PLUGIN_LDFLAGS ?= @PLUGIN_LDFLAGS@
 PATH_SEPARATOR ?= @PATH_SEPARATOR@
 EXEEXT ?= @EXEEXT@
-LIB_CPPFLAGS ?= @LIB_CPPFLAGS@
 exec_prefix ?= @exec_prefix@
 host_os ?= @host_os@
 target_os ?= @target_os@

--- a/m4/buildsys.m4
+++ b/m4/buildsys.m4
@@ -1,7 +1,8 @@
 dnl
-dnl Copyright (c) 2007 - 2009, Jonathan Schleifer <js@webkeks.org>
+dnl Copyright (c) 2007, 2008, 2009, 2010, 2011, 2012
+dnl Jonathan Schleifer <js@webkeks.org>
 dnl
-dnl https://webkeks.org/hg/buildsys/
+dnl https://webkeks.org/git/?p=buildsys.git
 dnl
 dnl Permission to use, copy, modify, and/or distribute this software for any
 dnl purpose with or without fee is hereby granted, provided that the above
@@ -20,13 +21,65 @@ dnl ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 dnl POSSIBILITY OF SUCH DAMAGE.
 dnl
 
-AC_DEFUN([BUILDSYS_LIB], [
-	AC_ARG_ENABLE(shared,
-		AS_HELP_STRING([--disable-shared], [don't build shared libraries]))
+AC_CONFIG_COMMANDS_PRE([
+	AC_SUBST(CC_DEPENDS, $GCC)
+	AC_SUBST(CXX_DEPENDS, $GXX)
+	AC_SUBST(OBJC_DEPENDS, $GOBJC)
+	AC_SUBST(OBJCXX_DEPENDS, $GOBJCXX)
 
-	AS_IF([test x"$enable_shared" = x"no"],
-		[BUILDSYS_STATIC_LIB_ONLY],
-		[BUILDSYS_SHARED_LIB])
+	AC_PATH_PROG(TPUT, tput)
+
+	AS_IF([test x"$TPUT" != x""], [
+		if x=$($TPUT el 2>/dev/null); then
+			AC_SUBST(TERM_EL, "$x")
+		else
+			AC_SUBST(TERM_EL, "$($TPUT ce 2>/dev/null)")
+		fi
+
+		if x=$($TPUT sgr0 2>/dev/null); then
+			AC_SUBST(TERM_SGR0, "$x")
+		else
+			AC_SUBST(TERM_SGR0, "$($TPUT me 2>/dev/null)")
+		fi
+
+		if x=$($TPUT bold 2>/dev/null); then
+			AC_SUBST(TERM_BOLD, "$x")
+		else
+			AC_SUBST(TERM_BOLD, "$($TPUT md 2>/dev/null)")
+		fi
+
+		if x=$($TPUT setaf 1 2>/dev/null); then
+			AC_SUBST(TERM_SETAF1, "$x")
+			AC_SUBST(TERM_SETAF2, "$($TPUT setaf 2 2>/dev/null)")
+			AC_SUBST(TERM_SETAF3, "$($TPUT setaf 3 2>/dev/null)")
+			AC_SUBST(TERM_SETAF4, "$($TPUT setaf 4 2>/dev/null)")
+			AC_SUBST(TERM_SETAF6, "$($TPUT setaf 6 2>/dev/null)")
+		else
+			AC_SUBST(TERM_SETAF1, "$($TPUT AF 1 2>/dev/null)")
+			AC_SUBST(TERM_SETAF2, "$($TPUT AF 2 2>/dev/null)")
+			AC_SUBST(TERM_SETAF3, "$($TPUT AF 3 2>/dev/null)")
+			AC_SUBST(TERM_SETAF4, "$($TPUT AF 4 2>/dev/null)")
+			AC_SUBST(TERM_SETAF6, "$($TPUT AF 6 2>/dev/null)")
+		fi
+	], [
+		AC_SUBST(TERM_EL, '\033\133K')
+		AC_SUBST(TERM_SGR0, '\033\133m')
+		AC_SUBST(TERM_BOLD, '\033\1331m')
+		AC_SUBST(TERM_SETAF1, '\033\13331m')
+		AC_SUBST(TERM_SETAF2, '\033\13332m')
+		AC_SUBST(TERM_SETAF3, '\033\13333m')
+		AC_SUBST(TERM_SETAF4, '\033\13334m')
+		AC_SUBST(TERM_SETAF6, '\033\13336m')
+	])
+])
+
+AC_CONFIG_COMMANDS_POST([
+	${as_echo:="echo"} ${as_me:="configure"}": touching .deps files"
+	for i in $(find . -name Makefile); do
+		DEPSFILE="$(dirname $i)/.deps"
+		test -f "$DEPSFILE" && rm "$DEPSFILE"
+		touch -t 0001010000 "$DEPSFILE"
+	done
 ])
 
 AC_DEFUN([BUILDSYS_PROG_IMPLIB], [
@@ -55,131 +108,85 @@ AC_DEFUN([BUILDSYS_SHARED_LIB], [
 	case "$host_os" in
 		darwin*)
 			AC_MSG_RESULT(Darwin)
-			LIB_CPPFLAGS='-DPIC'
-			LIB_CFLAGS='-fPIC'
-			LIB_LDFLAGS='-dynamiclib -flat_namespace'
+			LIB_CFLAGS='-fPIC -DPIC -mmacosx-version-min=10.7'
+			LIB_LDFLAGS='-dynamiclib -current_version ${LIB_MAJOR}.${LIB_MINOR} -compatibility_version ${LIB_MAJOR} -mmacosx-version-min=10.7 -install_name "${libdir}/$$(i=${SHARED_LIB}; echo $${i%${LIB_SUFFIX}}).${LIB_MAJOR}${LIB_SUFFIX}"'
 			LIB_PREFIX='lib'
 			LIB_SUFFIX='.dylib'
 			LDFLAGS_RPATH='-Wl,-rpath,${libdir}'
-			PLUGIN_CPPFLAGS='-DPIC'
-			PLUGIN_CFLAGS='-fPIC'
-			PLUGIN_LDFLAGS='-bundle -flat_namespace -undefined suppress'
-			PLUGIN_SUFFIX='.impl'
-			INSTALL_LIB='${INSTALL} -m 755 $$i ${DESTDIR}${libdir}/$${i%.dylib}.${LIB_MAJOR}.${LIB_MINOR}.dylib && ${LN_S} -f $${i%.dylib}.${LIB_MAJOR}.${LIB_MINOR}.dylib ${DESTDIR}${libdir}/$${i%.dylib}.${LIB_MAJOR}.dylib && ${LN_S} -f $${i%.dylib}.${LIB_MAJOR}.${LIB_MINOR}.dylib ${DESTDIR}${libdir}/$$i'
-			UNINSTALL_LIB='rm -f ${DESTDIR}${libdir}/$$i ${DESTDIR}${libdir}/$${i%.dylib}.${LIB_MAJOR}.dylib ${DESTDIR}${libdir}/$${i%.dylib}.${LIB_MAJOR}.${LIB_MINOR}.dylib'
+			PLUGIN_CFLAGS='-fPIC -DPIC -mmacosx-version-min=10.7'
+			PLUGIN_LDFLAGS='-bundle -undefined dynamic_lookup -mmacosx-version-min=10.7'
+			PLUGIN_SUFFIX='.bundle'
+			INSTALL_LIB='&& ${INSTALL} -m 755 $$i ${DESTDIR}${libdir}/$${i%.dylib}.${LIB_MAJOR}.${LIB_MINOR}.dylib && ${LN_S} -f $${i%.dylib}.${LIB_MAJOR}.${LIB_MINOR}.dylib ${DESTDIR}${libdir}/$${i%.dylib}.${LIB_MAJOR}.dylib && ${LN_S} -f $${i%.dylib}.${LIB_MAJOR}.${LIB_MINOR}.dylib ${DESTDIR}${libdir}/$$i'
+			UNINSTALL_LIB='&& rm -f ${DESTDIR}${libdir}/$$i ${DESTDIR}${libdir}/$${i%.dylib}.${LIB_MAJOR}.dylib ${DESTDIR}${libdir}/$${i%.dylib}.${LIB_MAJOR}.${LIB_MINOR}.dylib'
 			CLEAN_LIB=''
 			;;
 		solaris*)
 			AC_MSG_RESULT(Solaris)
-			LIB_CPPFLAGS='-DPIC'
-			LIB_CFLAGS='-fPIC'
-			LIB_LDFLAGS='-shared -fPIC -Wl,-soname=${LIB}.${LIB_MAJOR}.${LIB_MINOR}'
+			LIB_CFLAGS='-fPIC -DPIC'
+			LIB_LDFLAGS='-shared -Wl,-soname=${SHARED_LIB}.${LIB_MAJOR}.${LIB_MINOR}'
 			LIB_PREFIX='lib'
 			LIB_SUFFIX='.so'
 			LDFLAGS_RPATH='-Wl,-rpath,${libdir}'
-			PLUGIN_CPPFLAGS='-DPIC'
-			PLUGIN_CFLAGS='-fPIC'
-			PLUGIN_LDFLAGS='-shared -fPIC'
+			PLUGIN_CFLAGS='-fPIC -DPIC'
+			PLUGIN_LDFLAGS='-shared'
 			PLUGIN_SUFFIX='.so'
-			INSTALL_LIB='${INSTALL} -m 755 $$i ${DESTDIR}${libdir}/$$i.${LIB_MAJOR}.${LIB_MINOR} && rm -f ${DESTDIR}${libdir}/$$i && ${LN_S} $$i.${LIB_MAJOR}.${LIB_MINOR} ${DESTDIR}${libdir}/$$i'
-			UNINSTALL_LIB='rm -f ${DESTDIR}${libdir}/$$i ${DESTDIR}${libdir}/$$i.${LIB_MAJOR}.${LIB_MINOR}'
+			INSTALL_LIB='&& ${INSTALL} -m 755 $$i ${DESTDIR}${libdir}/$$i.${LIB_MAJOR}.${LIB_MINOR} && rm -f ${DESTDIR}${libdir}/$$i && ${LN_S} $$i.${LIB_MAJOR}.${LIB_MINOR} ${DESTDIR}${libdir}/$$i'
+			UNINSTALL_LIB='&& rm -f ${DESTDIR}${libdir}/$$i ${DESTDIR}${libdir}/$$i.${LIB_MAJOR}.${LIB_MINOR}'
 			CLEAN_LIB=''
 			;;
 		openbsd* | mirbsd*)
 			AC_MSG_RESULT(OpenBSD)
-			LIB_CPPFLAGS='-DPIC'
-			LIB_CFLAGS='-fPIC'
-			LIB_LDFLAGS='-shared -fPIC'
+			LIB_CFLAGS='-fPIC -DPIC'
+			LIB_LDFLAGS='-shared'
 			LIB_PREFIX='lib'
 			LIB_SUFFIX='.so.${LIB_MAJOR}.${LIB_MINOR}'
 			LDFLAGS_RPATH='-Wl,-rpath,${libdir}'
-			PLUGIN_CPPFLAGS='-DPIC'
-			PLUGIN_CFLAGS='-fPIC'
-			PLUGIN_LDFLAGS='-shared -fPIC'
+			PLUGIN_CFLAGS='-fPIC -DPIC'
+			PLUGIN_LDFLAGS='-shared'
 			PLUGIN_SUFFIX='.so'
-			INSTALL_LIB='${INSTALL} -m 755 $$i ${DESTDIR}${libdir}/$$i'
-			UNINSTALL_LIB='rm -f ${DESTDIR}${libdir}/$$i'
+			INSTALL_LIB='&& ${INSTALL} -m 755 $$i ${DESTDIR}${libdir}/$$i'
+			UNINSTALL_LIB='&& rm -f ${DESTDIR}${libdir}/$$i'
 			CLEAN_LIB=''
 			;;
 		cygwin* | mingw*)
 			AC_MSG_RESULT(Win32)
-			LIB_CPPFLAGS='-DPIC'
 			LIB_CFLAGS=''
-			LIB_LDFLAGS='-shared -Wl,--out-implib,${LIB}.a'
+			LIB_LDFLAGS='-shared -Wl,--out-implib,${SHARED_LIB}.a'
 			LIB_PREFIX='lib'
 			LIB_SUFFIX='.dll'
 			LDFLAGS_RPATH='-Wl,-rpath,${libdir}'
-			PLUGIN_CPPFLAGS=''
 			PLUGIN_CFLAGS=''
 			PLUGIN_LDFLAGS='-shared'
 			PLUGIN_SUFFIX='.dll'
-			INSTALL_LIB='${MKDIR_P} ${DESTDIR}${bindir} && ${INSTALL} -m 755 $$i ${DESTDIR}${bindir}/$$i && ${INSTALL} -m 755 $$i.a ${DESTDIR}${libdir}/$$i.a'
-			UNINSTALL_LIB='rm -f ${DESTDIR}${bindir}/$$i ${DESTDIR}${libdir}/$$i.a'
-			CLEAN_LIB='${LIB}.a'
+			INSTALL_LIB='&& ${MKDIR_P} ${DESTDIR}${bindir} && ${INSTALL} -m 755 $$i ${DESTDIR}${bindir}/$$i && ${INSTALL} -m 755 $$i.a ${DESTDIR}${libdir}/$$i.a'
+			UNINSTALL_LIB='&& rm -f ${DESTDIR}${bindir}/$$i ${DESTDIR}${libdir}/$$i.a'
+			CLEAN_LIB='${SHARED_LIB}.a'
 			;;
 		*)
 			AC_MSG_RESULT(GNU)
-			LIB_CPPFLAGS='-DPIC'
-			LIB_CFLAGS='-fPIC'
-			LIB_LDFLAGS='-shared -fPIC -Wl,-soname=${LIB}.${LIB_MAJOR}'
+			LIB_CFLAGS='-fPIC -DPIC'
+			LIB_LDFLAGS='-shared -Wl,-soname=${SHARED_LIB}.${LIB_MAJOR}'
 			LIB_PREFIX='lib'
 			LIB_SUFFIX='.so'
 			LDFLAGS_RPATH='-Wl,-rpath,${libdir}'
-			PLUGIN_CPPFLAGS='-DPIC'
-			PLUGIN_CFLAGS='-fPIC'
-			PLUGIN_LDFLAGS='-shared -fPIC'
+			PLUGIN_CFLAGS='-fPIC -DPIC'
+			PLUGIN_LDFLAGS='-shared'
 			PLUGIN_SUFFIX='.so'
-			INSTALL_LIB='${INSTALL} -m 755 $$i ${DESTDIR}${libdir}/$$i.${LIB_MAJOR}.${LIB_MINOR}.0 && ${LN_S} -f $$i.${LIB_MAJOR}.${LIB_MINOR}.0 ${DESTDIR}${libdir}/$$i.${LIB_MAJOR} && ${LN_S} -f $$i.${LIB_MAJOR}.${LIB_MINOR}.0 ${DESTDIR}${libdir}/$$i'
-			UNINSTALL_LIB='rm -f ${DESTDIR}${libdir}/$$i ${DESTDIR}${libdir}/$$i.${LIB_MAJOR} ${DESTDIR}${libdir}/$$i.${LIB_MAJOR}.${LIB_MINOR}.0'
+			INSTALL_LIB='&& ${INSTALL} -m 755 $$i ${DESTDIR}${libdir}/$$i.${LIB_MAJOR}.${LIB_MINOR}.0 && ${LN_S} -f $$i.${LIB_MAJOR}.${LIB_MINOR}.0 ${DESTDIR}${libdir}/$$i.${LIB_MAJOR} && ${LN_S} -f $$i.${LIB_MAJOR}.${LIB_MINOR}.0 ${DESTDIR}${libdir}/$$i'
+			UNINSTALL_LIB='&& rm -f ${DESTDIR}${libdir}/$$i ${DESTDIR}${libdir}/$$i.${LIB_MAJOR} ${DESTDIR}${libdir}/$$i.${LIB_MAJOR}.${LIB_MINOR}.0'
 			CLEAN_LIB=''
 			;;
 	esac
 
-	AC_SUBST(LIB_CPPFLAGS)
 	AC_SUBST(LIB_CFLAGS)
 	AC_SUBST(LIB_LDFLAGS)
 	AC_SUBST(LIB_PREFIX)
 	AC_SUBST(LIB_SUFFIX)
 	AC_SUBST(LDFLAGS_RPATH)
-	AC_SUBST(PLUGIN_CPPFLAGS)
 	AC_SUBST(PLUGIN_CFLAGS)
 	AC_SUBST(PLUGIN_LDFLAGS)
 	AC_SUBST(PLUGIN_SUFFIX)
 	AC_SUBST(INSTALL_LIB)
 	AC_SUBST(UNINSTALL_LIB)
 	AC_SUBST(CLEAN_LIB)
-])
-
-AC_DEFUN([BUILDSYS_STATIC_LIB_ONLY], [
-	AC_REQUIRE([AC_PROG_RANLIB])
-	AC_PATH_TOOL(AR, ar)
-
-	LIB_CPPFLAGS=''
-	LIB_CFLAGS=''
-	LIB_LDFLAGS=''
-	LIB_PREFIX='lib'
-	LIB_SUFFIX='.a'
-	LDFLAGS_RPATH=''
-	INSTALL_LIB='${INSTALL} -m 644 $$i ${DESTDIR}${libdir}/$$i'
-	UNINSTALL_LIB='rm -f ${DESTDIR}${libdir}/$$i'
-	CLEAN_LIB=''
-
-	AC_SUBST(LIB_CPPFLAGS)
-	AC_SUBST(LIB_CFLAGS)
-	AC_SUBST(LIB_LDFLAGS)
-	AC_SUBST(LIB_PREFIX)
-	AC_SUBST(LIB_SUFFIX)
-	AC_SUBST(LDFLAGS_RPATH)
-	AC_SUBST(INSTALL_LIB)
-	AC_SUBST(UNINSTALL_LIB)
-	AC_SUBST(CLEAN_LIB)
-])
-
-AC_DEFUN([BUILDSYS_TOUCH_DEPS], [
-	${as_echo:="echo"} "${as_me:="configure"}: touching .deps files"
-	for i in $(find . -name Makefile); do
-		DEPSFILE="$(dirname $i)/.deps"
-		test -f "$DEPSFILE" && rm "$DEPSFILE"
-		touch -t 0001010000 "$DEPSFILE"
-	done
 ])

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,7 @@
 SUBDIRS = libguess tests ${EXAMPLES_BUILD}
 
+tests: libguess
+examples: libguess
+
 include ../buildsys.mk
 include ../extra.mk

--- a/src/libguess/Makefile
+++ b/src/libguess/Makefile
@@ -1,4 +1,4 @@
-LIB = ${LIB_PREFIX}guess${LIB_SUFFIX}
+SHARED_LIB = ${LIB_PREFIX}guess${LIB_SUFFIX}
 LIB_MAJOR = 1
 LIB_MINOR = 0
 DISTCLEAN = autoconf.h
@@ -12,5 +12,5 @@ INCLUDES = libguess.h
 include ../../buildsys.mk
 include ../../extra.mk
 
-CPPFLAGS += ${LIB_CPPFLAGS} -I. -I.. -DLIBGUESS_CORE
+CPPFLAGS += -I. -I.. -DLIBGUESS_CORE
 CFLAGS += ${LIB_CFLAGS}


### PR DESCRIPTION
buildsys.mk.in and buildsys.m4 are taken from Audacious

Before:

    $ /Software/Audacious/bin/audacious
    dyld: Library not loaded: libguess.dylib
      Referenced from: /Software/Audacious/lib/libaudcore.3.dylib
      Reason: image not found
    [1]    49021 trace trap  /Software/Audacious/bin/audacious


    $ otool -L /Software/Audacious/lib/libaudcore.dylib
    /Software/Audacious/lib/libaudcore.dylib:
      /Software/Audacious/lib/libaudcore.3.dylib (compatibility version 3.0.0, current version 3.0.0)
      /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.0.0)
      /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
      /Software/Audacious/lib/libintl.8.dylib (compatibility version 10.0.0, current version 10.2.0)
      /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
      /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1151.16.0)
      /Software/Audacious/lib/libglib-2.0.0.dylib (compatibility version 4001.0.0, current version 4001.0.0)
      /Software/Audacious/lib/libgmodule-2.0.0.dylib (compatibility version 4001.0.0, current version 4001.0.0)
      libguess.dylib (compatibility version 0.0.0, current version 0.0.0)
      /Software/Audacious/lib/QtCore.framework/Versions/5/QtCore (compatibility version 5.3.0, current version 5.3.2)
      /Software/Audacious/lib/QtGui.framework/Versions/5/QtGui (compatibility version 5.3.0, current version 5.3.2)
      /Software/Audacious/lib/QtWidgets.framework/Versions/5/QtWidgets (compatibility version 5.3.0, current version 5.3.2)

After:

    $ otool -L /Software/Audacious/lib/libaudcore.dylib
    /Software/Audacious/lib/libaudcore.dylib:
      /Software/Audacious/lib/libaudcore.3.dylib (compatibility version 3.0.0, current version 3.0.0)
      /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.0.0)
      /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
      /Software/Audacious/lib/libintl.8.dylib (compatibility version 10.0.0, current version 10.2.0)
      /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
      /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1151.16.0)
      /Software/Audacious/lib/libglib-2.0.0.dylib (compatibility version 4001.0.0, current version 4001.0.0)
      /Software/Audacious/lib/libgmodule-2.0.0.dylib (compatibility version 4001.0.0, current version 4001.0.0)
      /Software/Audacious/lib/libguess.1.dylib (compatibility version 1.0.0, current version 1.0.0)
      /Software/Audacious/lib/QtCore.framework/Versions/5/QtCore (compatibility version 5.3.0, current version 5.3.2)
      /Software/Audacious/lib/QtGui.framework/Versions/5/QtGui (compatibility version 5.3.0, current version 5.3.2)
      /Software/Audacious/lib/QtWidgets.framework/Versions/5/QtWidgets (compatibility version 5.3.0, current version 5.3.2)